### PR TITLE
test: fix configs and path

### DIFF
--- a/packages/view3d/test/suite/core/annotation/AnnotationManager.spec.ts
+++ b/packages/view3d/test/suite/core/annotation/AnnotationManager.spec.ts
@@ -1,5 +1,5 @@
 import { PointAnnotation } from "~/core";
-import AnnotationManager from "~/core/annotation/AnnotationManager";
+import AnnotationManager from "~/annotation/AnnotationManager";
 import { range } from "~/utils";
 import { createView3D } from "../../../test-utils";
 

--- a/packages/view3d/test/tsconfig.json
+++ b/packages/view3d/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2015",
+    "moduleResolution": "node",
     "lib": ["ES2015", "dom"],
     "types": ["cypress"],
     "baseUrl": ".",


### PR DESCRIPTION
When I test written typescript code as extends of class using cypress appear issue.
`Uncaught TypeError: Class constructor UnrealBloomPass cannot be invoked without 'new’`

The code is defined below:
<img width="569" alt="sshot" src="https://user-images.githubusercontent.com/21374353/206857488-971a35fc-1df9-471e-b2f9-16576f202542.png">

I found issue cause in refer to https://stackoverflow.com/a/51860850
So I fixed target "es5" -> "ES2015" and add moduleResolution option in tsconfig.

The other one is I fixed invalid path in AnnotationManager.spec.ts file.
